### PR TITLE
Fix padding for anchor-linked workflow images

### DIFF
--- a/template/public/workflow.css
+++ b/template/public/workflow.css
@@ -3,7 +3,8 @@
   padding: 1px;
 }
 
-.workflow > p > img {
+.workflow > p > img,
+.workflow > p > a > img {
   padding-top: 12px;
   padding-left: 12px;
   padding-right: 12px;


### PR DESCRIPTION
In [Docfx images are made clickable](https://github.com/dotnet/docfx/blob/0cceb23227448b9e1767814df172568bbc08e281/templates/modern/src/markdown.ts#L97) when the size exceeds 200 x 200. 

This PR closes #19 by adding a selector for workflow `<img>` elements that are direct children of `<a>` tags.

The alternative is to apply the CSS style to all `<img>` elements in workflow:
```css
.workflow img {
  padding-top: 12px;
  padding-left: 12px;
  padding-right: 12px;
}
```