### PR TITLE
Make copy button icon permanent and strip its white space

### DIFF
--- a/template/public/workflow.css
+++ b/template/public/workflow.css
@@ -15,3 +15,7 @@
   max-width: 50%;
   float: inline-end;
 }
+
+pre > .code-action:has(+ div.workflow) {
+  display: block;
+}

--- a/template/public/workflow.js
+++ b/template/public/workflow.js
@@ -3,7 +3,7 @@ export default {
         const wrap = document.createElement("pre");
         wrap.innerHTML =
             '<a class="btn border-0 code-action" href="#" title="Copy">'+
-            '  <i class="bi bi-clipboard"></i>'+
+            '<i class="bi bi-clipboard"></i>'+
             '</a>';
         const button = wrap.querySelector("a");
         button.addEventListener("click", (e) => {


### PR DESCRIPTION
This PR does two things: makes copy icon appear permanently (instead of only appearing when hovering over the workflow) and strips white space from the copy button. I'm not sure if y'all want this, but I think it's worth considering. We will probably make these additions in our files in the open ephys docs if you don't here.

# Make copy button permanent

![image](https://github.com/user-attachments/assets/20791997-8e18-44bd-831b-7bf24c677412)

Currently the copy button icon only appears when the cursor hovers over the workflow container. I propose that the copy button appears permanently. This is meant to address the first item in the bullet point of [this issue](https://github.com/open-ephys/bonsai-onix1-docs/issues/188). This accomplished by 3e90c1a.

# Strip white space from copy button


![image](https://github.com/user-attachments/assets/04b51fa4-54d3-42da-b5f3-471ab0264c34) &nbsp;&nbsp;&nbsp; --> &nbsp;&nbsp;&nbsp; ![Screenshot 2025-01-21 215509](https://github.com/user-attachments/assets/c41f236f-211f-4fa8-b2f0-9c59bceea890) 

The copy button clickable area extends from the clipboard button to the left. Any whitespace contained by an HTML `<pre>` tag is rendered. Not sure if this was intentional. I propose removing that white space.  This is accomplished by 7a2580b.