### PR TITLE
Improve robustness of Export-Image and add ability to choose specific output path

### DIFF
--- a/modules/Export-Image.ps1
+++ b/modules/Export-Image.ps1
@@ -1,31 +1,52 @@
-param(
+[CmdletBinding()] param(
     [string[]]$libPath,
     [string]$workflowPath=".\workflows",
-    [string]$bootstrapperPath="..\.bonsai\Bonsai.exe"
+    [string]$bootstrapperPath="..\.bonsai\Bonsai.exe",
+    [string]$outputFolder="",
+    [string]$documentationRoot="" # Only relevant when outputFolder is set
 )
 
-function Export-Svg([string[]]$libPath, [string]$svgFileName, [string]$workflowFile)
-{
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+function Export-Svg([string[]]$libPath, [string]$svgPath, [string]$workflowFile) {
     $bootstrapperArgs = @()
     foreach ($path in $libPath) {
         $bootstrapperArgs += "--lib"
         $bootstrapperArgs += "$(Resolve-Path $path)"
     }
     $bootstrapperArgs += "--export-image"
-    $bootstrapperArgs += "$svgFileName"
+    $bootstrapperArgs += "$svgPath"
     $bootstrapperArgs += "$workflowFile"
+
+    if (!$IsWindows) {
+        $bootstrapperArgs = @($bootstrapperPath) + $bootstrapperArgs
+        $bootstrapperPath = 'mono'
+    }
 
     Write-Verbose "$($bootstrapperPath) $($bootstrapperArgs)"
     &$bootstrapperPath $bootstrapperArgs
 }
 
-Import-Module (Join-Path $PSScriptRoot "Export-Tools.psm1")
+if (-not $documentationRoot) {
+    $documentationRoot = Resolve-Path $workflowPath
+}
+
+Import-Module (Join-Path $PSScriptRoot "Export-Tools.psm1") -Verbose:$false
+
 $sessionPath = $ExecutionContext.SessionState.Path
 foreach ($workflowFile in Get-ChildItem -File -Recurse (Join-Path $workflowPath "*.bonsai")) {
-    $svgFileName = "$($workflowFile.BaseName).svg"
-    Write-Host "Exporting $($svgFileName)"
-    $svgFileDirectory = Split-Path -Parent $workflowFile.FullName
-    $svgFile = $sessionPath.GetUnresolvedProviderPathFromPSPath((Join-Path $svgFileDirectory $svgFileName))
-    Export-Svg $libPath $svgFileName $workflowFile
-    Convert-Svg $svgFile
+    $svgPath = Join-Path $workflowFile.DirectoryName "$($workflowFile.BaseName).svg"
+    $svgPathRelative = [IO.Path]::GetRelativePath($documentationRoot, $svgPath)
+
+    if ($outputFolder) {
+        $svgPath = Join-Path $outputFolder $svgPathRelative
+        $null = New-Item -ItemType Directory -Path (Split-Path -Parent $svgPath) -Force
+    }
+
+    Write-Host "Exporting $($svgPathRelative)"
+    Write-Verbose "Exporting to $($svgPath)"
+    Export-Svg $libPath $svgPath $workflowFile
+    Convert-Svg $svgPath
 }


### PR DESCRIPTION
This PR modifies `Export-Image.ps1` to:

* Propagate failure properly
* Propagates `-Verbose`
* Allows overriding the output directory (for common CI)
* Improves the output to be more clear when there's more than one directory containing workflows
* Maybe other things too, my brain is currently potato++ and I made these changes a while ago