### PR TITLE
Add main CSS file with recommended styles

### DIFF
--- a/template/public/bonsai.css
+++ b/template/public/bonsai.css
@@ -1,0 +1,19 @@
+@import "workflow.css";
+
+/* ==========================================================================
+   KEYBOARD SHORTCUT STYLE
+   ========================================================================== */
+
+kbd {
+    color: var(--bs-body-color);
+    vertical-align: middle;
+    background-color: var(--bs-body-bg);
+    border: solid 1px var(--bs-secondary);
+    border-bottom-color: var(--bs-secondary);
+    box-shadow: inset 0 -1px 0 var(--bs-secondary-bg-subtle);
+    border-radius: .25rem;
+    padding: .25rem;
+    font-size: .75rem;
+    line-height: 10px;
+    display: inline-block;
+}


### PR DESCRIPTION
`bonsai.css` should now be the main file included from the local docs template in order to allow theming of specific elements.

In the first version we improve styling of keyboard shortcuts.